### PR TITLE
feat: docker 파일 로컬에서 실행되도록 수정

### DIFF
--- a/eatngo-customer-api/Dockerfile
+++ b/eatngo-customer-api/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /app
 # JAR 파일만 복사 (로컬에서 미리 build되어 있어야 함)
 COPY eatngo-customer-api/build/libs/*.jar app.jar
 
-ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-Dhttps.protocols=TLSv1.2", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=local", "-Dhttps.protocols=TLSv1.2", "-jar", "app.jar"]

--- a/eatngo-customer-api/src/main/resources/application-dev.yml
+++ b/eatngo-customer-api/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ spring:
     name: eatngo-customer-api
   datasource:
     url: ${PG_URL}
-    username: eatngo_user
+    username: eatngo_admin
     password: ${PG_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:

--- a/eatngo-store-owner-api/Dockerfile
+++ b/eatngo-store-owner-api/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 # JAR 파일만 복사 (로컬에서 미리 build되어 있어야 함)
 COPY eatngo-store-owner-api/build/libs/*.jar app.jar
 
-ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-Dhttps.protocols=TLSv1.2", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=local", "-Dhttps.protocols=TLSv1.2", "-jar", "app.jar"]

--- a/scripts/local/docker-compose.yml
+++ b/scripts/local/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - pg_data:/var/lib/postgresql/data
     restart: unless-stopped
 
+ # TODO : Atlas 연결 or 로컬에서도 검색 동작하도록 수정
   mongodb:
     image: mongo:8
     container_name: eatngo-mongodb
@@ -35,6 +36,32 @@ services:
     command: redis-server --requirepass eatngolocal
     volumes:
         - redis_data:/data
+    restart: unless-stopped
+
+  customer-api:
+    build:
+      context: ../../eatngo-customer-api
+      dockerfile: Dockerfile
+    container_name: eatngo-customer-api
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres
+      - mongodb
+      - redis
+    restart: unless-stopped
+
+  store-owner-api:
+    build:
+      context: ../../eatngo-store-owner-api
+      dockerfile: Dockerfile
+    container_name: store-owner-api
+    ports:
+      - "8081:8081"
+    depends_on:
+      - postgres
+      - mongodb
+      - redis
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
- 도커컴포즈에서 로컬 실행 수정
- todo : pg 데이터 밀어넣기 / mongodb Atlas로 연결되도록 수정 -> 파라미터 스토어 이용? 민감정보 어떻게 할지 확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * docker-compose에 customer-api와 store-owner-api 서비스가 추가되어 로컬 환경에서 각각 8080, 8081 포트로 실행할 수 있습니다.

* **환경 설정**
  * customer-api 및 store-owner-api의 실행 프로필이 "dev"에서 "local"로 변경되었습니다.
  * 개발 환경의 데이터베이스 사용자명이 "eatngo_user"에서 "eatngo_admin"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->